### PR TITLE
Resolved pin conflict with PSRAM.

### DIFF
--- a/src/Platforms/VisionMasterE213/VisionMasterE213.h
+++ b/src/Platforms/VisionMasterE213/VisionMasterE213.h
@@ -24,7 +24,7 @@
         #define ALL_IN_ONE              true            // Allow a short constructor: display pins are fixed
         #define DEFAULT_SDI             6
         #define DEFAULT_CLK             4
-        #define DEFAULT_MISO            33              // Arbitrary, not connected on PCB. Suppress compiler warning
+        #define DEFAULT_MISO            40              // Arbitrary, not connected on PCB. Suppress compiler warning
         
         // Paging
         #define DEFAULT_PAGE_HEIGHT     panel_height    // On this platform, these defaults are fixed: there is currently no support for paging

--- a/src/Platforms/VisionMasterE290/VisionMasterE290.h
+++ b/src/Platforms/VisionMasterE290/VisionMasterE290.h
@@ -19,7 +19,7 @@
         #define ALL_IN_ONE              true            // Allow a short constructor: display pins are fixed
         #define DEFAULT_SDI             1
         #define DEFAULT_CLK             2
-        #define DEFAULT_MISO            33              // Arbitrary, not connected on PCB. Suppress compiler warning.
+        #define DEFAULT_MISO            40              // Arbitrary, not connected on PCB. Suppress compiler warning.
         
         // Paging
         #define DEFAULT_PAGE_HEIGHT     panel_height    // On this platform, these defaults are fixed: there is currently no support for paging


### PR DESCRIPTION
Pin 33 is used by PSRAM. Using it for other functions will cause abnormalities.